### PR TITLE
AI-670: Set minimum python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 description = "Web interface for Solace Agent Mesh"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "flask~=3.0.3",
     "requests~=2.32.3",
@@ -62,7 +62,7 @@ installer = "pip"
 
 # Specify minimum and maximum Python versions to test
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.12"]
+python = ["3.10", "3.11", "3.12"]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ installer = "pip"
 
 # Specify minimum and maximum Python versions to test
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.12"]
 
 
 [tool.ruff]


### PR DESCRIPTION
## What is the purpose of this change?

This change lowers the minimum Python version requirement from 3.11 to 3.10 to increase compatibility with systems that may not have Python 3.11 installed.

## How is this accomplished?

By updating the `requires-python` field in the pyproject.toml file to specify a minimum Python version of 3.10 instead of 3.11, and ensuring the test matrix covers Python 3.10, 3.11, and 3.12.

## Anything reviews should focus on/be aware of?

Reviewers should verify that all code features are compatible with Python 3.10, as there may be language features or dependencies that were introduced in Python 3.11 that would need to be modified.