### PR TITLE
AI-657 : Fix localhost CORS bug

### DIFF
--- a/src/solace_ai_connector_web/backend/server_base.py
+++ b/src/solace_ai_connector_web/backend/server_base.py
@@ -3,6 +3,7 @@ from flask import Flask, make_response, jsonify
 from flask_cors import CORS
 from solace_ai_connector.components.component_base import ComponentBase
 from flask_wtf import CSRFProtect
+from urllib.parse import urlparse
 import os
 
 info = {
@@ -216,13 +217,24 @@ class RestBase(ComponentBase):
         self.app.config['SECRET_KEY'] = self.csrf_key
         csrf.init_app(self.app)
         
+        frontend_origins = [self.frontend_url]
+    
+        # if frontend_url is using localhost or 127.0.0.1, then add them both to cors origins
+        if "localhost" in self.frontend_url or "127.0.0.1" in self.frontend_url:
+            parsed_url = urlparse(self.frontend_url)
+            scheme = parsed_url.scheme
+            port = f":{parsed_url.port}" if parsed_url.port else ""
+            
+            if "localhost" in self.frontend_url:
+                frontend_origins.append(f"{scheme}://127.0.0.1{port}")
+            else:
+                frontend_origins.append(f"{scheme}://localhost{port}")
+        
         CORS(
             self.app,
             resources={
                 r"/*": {
-                    "origins": [
-                        self.frontend_url,
-                    ],
+                    "origins": frontend_origins,
                     "supports_credentials": True
                 },
             },


### PR DESCRIPTION
Fixes the CORS issue by adding both `localhost` and `127.0.0.1 `to the CORS list, this should allow the user to access the web ui from `localhost` or `127.0.0.1`